### PR TITLE
allow branch name contains slashes

### DIFF
--- a/deploy
+++ b/deploy
@@ -207,7 +207,7 @@ setup() {
   local path=`config_get path`
   local repo=`config_get repo`
   local ref=`config_get ref`
-  local branch=${ref##*/}
+  local branch=${ref#*/}
   hook_pre_setup || abort pre-setup hook failed
   run "mkdir -p $path/{shared/{logs,pids},source}"
   test $? -eq 0 || abort setup paths failed


### PR DESCRIPTION
for example: we can deploy to a branch like "ref": "origin/deploy/test",